### PR TITLE
feat: Comprehensive Admin Panel UI/UX Review & Enhancement

### DIFF
--- a/lib/screens/admin/admin.dart
+++ b/lib/screens/admin/admin.dart
@@ -146,7 +146,7 @@ class _AdminDashboardState extends State<AdminDashboard> {
         'icon': Icons.support_agent_outlined, // Changed from people_outline_outlined
         'title': 'Users\nSupport',
         'onPressed': () => Get.to(() => const ChatScreen()), // Assuming ChatScreen is general support
-        'color': Colors.orange.shade700, // A distinct color for support, can be from extended color scheme
+        'color': colorScheme.tertiary, // Changed from Colors.orange.shade700
       },
     ];
 

--- a/lib/screens/admin/all_landlords.dart
+++ b/lib/screens/admin/all_landlords.dart
@@ -1,58 +1,188 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:cloudkeja/helpers/constants.dart';
-import 'package:cloudkeja/helpers/loading_effect.dart';
 import 'package:cloudkeja/models/user_model.dart';
 import 'package:cloudkeja/providers/admin_provider.dart';
 import 'package:cloudkeja/screens/admin/user_actions.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
-class AllLandlordsScreen extends StatelessWidget {
+class AllLandlordsScreen extends StatefulWidget {
   const AllLandlordsScreen({Key? key}) : super(key: key);
 
   @override
+  State<AllLandlordsScreen> createState() => _AllLandlordsScreenState();
+}
+
+class _AllLandlordsScreenState extends State<AllLandlordsScreen> {
+  List<UserModel> _landlords = [];
+  bool _isLoading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchLandlords();
+  }
+
+  Future<void> _fetchLandlords() async {
+    if (!mounted) return;
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final fetchedLandlords = await Provider.of<AdminProvider>(context, listen: false).getAllLandlords();
+      if (mounted) {
+        setState(() {
+          _landlords = fetchedLandlords;
+          _isLoading = false;
+        });
+      }
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = error.toString();
+          _landlords = [];
+          _isLoading = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to load landlords: $_errorMessage', style: TextStyle(color: Theme.of(context).colorScheme.onError)),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+
+  Widget _buildLandlordTile(BuildContext context, UserModel landlord, ThemeData theme, ColorScheme colorScheme, TextTheme textTheme) {
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: colorScheme.surfaceVariant,
+        backgroundImage: (landlord.profile != null && landlord.profile!.isNotEmpty)
+            ? NetworkImage(landlord.profile!)
+            : null,
+        child: (landlord.profile == null || landlord.profile!.isEmpty)
+            ? Icon(Icons.person_outline_rounded, color: colorScheme.onSurfaceVariant)
+            : null,
+      ),
+      title: Row(
+        children: [
+          Flexible(child: Text(landlord.name ?? 'N/A', style: textTheme.titleMedium, overflow: TextOverflow.ellipsis)),
+          if (landlord.isAdmin == true) ...[
+            const SizedBox(width: 5),
+            Icon(Icons.shield_outlined, color: colorScheme.secondary, size: 18),
+          ],
+        ],
+      ),
+      subtitle: Text(landlord.email ?? 'No email', style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurface.withOpacity(0.7))),
+      trailing: Icon(Icons.arrow_forward_ios, size: 16, color: colorScheme.outline.withOpacity(0.7)),
+      onTap: () {
+        actionSheet(context, landlord, theme); // Pass theme object
+      },
+    );
+  }
+
+  Widget _buildSkeletonTile(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: theme.colorScheme.surfaceVariant.withOpacity(0.5),
+      ),
+      title: Container(
+        height: 16,
+        width: MediaQuery.of(context).size.width * 0.4,
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.5),
+      ),
+      subtitle: Container(
+        height: 12,
+        width: MediaQuery.of(context).size.width * 0.6,
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.5),
+        margin: const EdgeInsets.only(top: 4),
+      ),
+      trailing: Icon(Icons.arrow_forward_ios, size: 16, color: theme.colorScheme.outline.withOpacity(0.3)),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+    final TextTheme textTheme = theme.textTheme;
+
+    Widget content;
+
+    if (_isLoading && _landlords.isEmpty) {
+      content = Skeletonizer(
+        enabled: true,
+        child: ListView.separated(
+          itemCount: 10, // Number of skeleton items
+          itemBuilder: (context, index) => _buildSkeletonTile(context),
+          separatorBuilder: (context, index) => Divider(indent: 16, endIndent: 16, height: 1, color: theme.dividerColor.withOpacity(0.1)),
+        ),
+      );
+    } else if (_errorMessage != null) {
+      content = Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.error_outline, color: colorScheme.error, size: 60),
+              const SizedBox(height: 16),
+              Text('Something Went Wrong', style: textTheme.titleLarge?.copyWith(color: colorScheme.error)),
+              const SizedBox(height: 8),
+              Text(_errorMessage!, textAlign: TextAlign.center, style: textTheme.bodyMedium),
+            ],
+          ),
+        ),
+      );
+    } else if (_landlords.isEmpty) {
+      content = Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.real_estate_agent_outlined, size: 80, color: colorScheme.primary.withOpacity(0.6)),
+              const SizedBox(height: 20),
+              Text("No Landlords Found", style: textTheme.titleLarge),
+              const SizedBox(height: 8),
+              Text(
+                "There are currently no users designated as landlords.",
+                style: textTheme.bodyMedium?.copyWith(color: colorScheme.onSurface.withOpacity(0.7)),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    } else {
+      content = ListView.separated(
+        itemCount: _landlords.length,
+        itemBuilder: (context, index) {
+          final landlord = _landlords[index];
+          return _buildLandlordTile(context, landlord, theme, colorScheme, textTheme);
+        },
+        separatorBuilder: (context, index) => Divider(
+          indent: 16,
+          endIndent: 16,
+          height: 1,
+          color: theme.dividerColor.withOpacity(0.5)
+        ),
+      );
+    }
+
     return Scaffold(
+      backgroundColor: colorScheme.background,
       appBar: AppBar(
         title: const Text('All Landlords'),
+        // AppBar theming will be inherited from AppTheme
       ),
-      body: FutureBuilder<List<UserModel>>(
-          future: Provider.of<AdminProvider>(context, listen: false)
-              .getAllLandlords(),
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return LoadingEffect.getSearchLoadingScreen(context);
-            }
-
-            return ListView(
-                children: snapshot.data!
-                    .map(
-                      (e) => ListTile(
-                        title: Row(
-                          children: [
-                            Text(e.name!),
-                            const SizedBox(
-                              width: 5,
-                            ),
-                            if (e.isAdmin!)
-                              const Icon(
-                                Icons.verified,
-                                color: kPrimaryColor,
-                                size: 16,
-                              )
-                          ],
-                        ),
-                        onTap: () {
-                          actionSheet(context, e);
-                        },
-                        subtitle: Text(e.email!),
-                        leading: CircleAvatar(
-                          backgroundColor: Colors.grey,
-                          backgroundImage: NetworkImage(e.profile!),
-                        ),
-                      ),
-                    )
-                    .toList());
-          }),
+      body: RefreshIndicator(
+        onRefresh: _fetchLandlords,
+        child: content,
+      ),
     );
   }
 }

--- a/lib/screens/admin/alll_users_screen.dart
+++ b/lib/screens/admin/alll_users_screen.dart
@@ -80,6 +80,35 @@ class _AllUsersScreenState extends State<AllUsersScreen> {
     });
   }
 
+  Widget _buildSkeletonTile(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: theme.colorScheme.surfaceVariant.withOpacity(0.5), // Placeholder color
+      ),
+      title: Container(
+        height: 16,
+        width: MediaQuery.of(context).size.width * 0.3, // Shorter width
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.5),
+        margin: const EdgeInsets.only(bottom: 4), // Add some margin like real text
+      ),
+      subtitle: Container(
+        height: 12,
+        width: MediaQuery.of(context).size.width * 0.5, // Medium width
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.5),
+      ),
+      trailing: Container( // Placeholder for the chip
+        height: 24, // Approx height of a chip
+        width: 50,  // Approx width of a chip
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceVariant.withOpacity(0.5),
+          borderRadius: BorderRadius.circular(8), // Chip-like radius
+        ),
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0), // Match real tile
+    );
+  }
+
   Widget _buildFilterDropdowns(BuildContext context) {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
@@ -193,12 +222,7 @@ class _AllUsersScreenState extends State<AllUsersScreen> {
                       itemCount: _isLoading ? 8 : _filteredUsers.length, // Show 8 skeleton items
                       itemBuilder: (context, index) {
                         if (_isLoading) {
-                          // Simple skeleton ListTile
-                          return ListTile(
-                            leading: const CircleAvatar(backgroundColor: Colors.transparent),
-                            title: Container(height: 16, width: 150, color: Colors.transparent),
-                            subtitle: Container(height: 12, width: 200, color: Colors.transparent),
-                          );
+                          return _buildSkeletonTile(context);
                         }
                         final user = _filteredUsers[index];
                         Widget? trailingWidget;

--- a/lib/screens/admin/user_actions.dart
+++ b/lib/screens/admin/user_actions.dart
@@ -139,7 +139,13 @@ void actionSheet(BuildContext context, UserModel user, ThemeData theme) {
                 Divider(color: theme.dividerColor),
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8.0),
-                  child: Text("Service Provider Actions", style: textTheme.labelLarge?.copyWith(color: colorScheme.onSurfaceVariant)),
+                  child: Text(
+                    "Service Provider Actions",
+                    style: textTheme.titleSmall?.copyWith(
+                        color: colorScheme.secondary,
+                        fontWeight: FontWeight.w600
+                    ),
+                  ),
                 ),
                 ListTile(
                   dense: true,


### PR DESCRIPTION
This commit applies a holistic UI/UX review and enhancement to the Admin Panel screens, ensuring consistency with your application's Material 3 theme (light/dark modes) and improving usability.

Key Changes:
1.  **`AllLandlordsScreen` Overhaul:**
    *   Fully themed to match `AppTheme` (AppBar, Scaffold, ListTiles, icons, text).
    *   Replaced old loading effect with themed `Skeletonizer` and appropriate skeleton tiles.
    *   Added a themed empty state message if no landlords are found.
    *   Implemented `RefreshIndicator` for pull-to-refresh.
    *   Corrected the `actionSheet` call to pass `ThemeData`.

2.  **`AdminDashboard` Minor Theming:**
    *   The 'Users Support' action button color was updated to use a theme-derived color (`colorScheme.tertiary`) for better consistency.

3.  **`AllUsersScreen` Minor Theming:**
    *   The skeleton `ListTile` was improved to be more representative of the actual content, including placeholders for avatar, text lines, and a trailing chip area, using themed elements.

4.  **`actionSheet` Minor Theming:**
    *   Internal section titles (e.g., 'Service Provider Actions') are now styled more consistently and clearly using `textTheme.titleSmall` with a theme-derived accent color.

These changes bring all primary admin screens (`AdminDashboard`, `AllUsersScreen`, `AllLandlordsScreen`, and the `actionSheet` modal) to a consistent level of UI polish and thematic alignment.